### PR TITLE
Adding all bible book names as abbreviations

### DIFF
--- a/syntok/_segmentation_states.py
+++ b/syntok/_segmentation_states.py
@@ -67,21 +67,18 @@ class State(metaclass=ABCMeta):
 
     abbreviations = frozenset(
         """
-    Abb Abs Adm adm afmo Alt alt Anl ap apdo approx Approx Art art atte atto Aufl
-    ave Ave Az Bd Bmo bmo brig Brig bsp Bsp bspw bzgl bzw ca cap capt Capt cf Cmdt
-    cmdt cnel Cnel Co col Col Corp Dan de Deut dgl Dr dt Ecc Eccl emp en Eph es
-    Est Esth etc evtl Ex exca Exca excl excmo Excmo Exo Exod exsmo Exsmo Ezek Ezra
-    ff Fig fig figs Figs Fr fr Gal gal gen Gen ggf GmbH Gob gob Gral gral Hab Hag
-    Hd Heb hno Hno hnos Hnos Hos Inc incl inkl Isa Jas Jer Jon Josh Judg Lam Ldo 
-    ldo Lev Lic lic lit Ltd mag Mag Mal Matt max med Med Mic min Mio mos mr Mr Mrd
-    mrs Mrs Ms ms mt Mt MwSt Nah Nat nat Neh nr Nr Ntra ntra Ntro ntro Num Oba Obad
-    pag Phil phil Phlm Pro Prof prof Prov Ps Psalm Rer rer resp Rev Rom Sci sci Song
-    Sr sr sra Sra srta Srta St st synth tab Tab Tel tel Univ univ Urt Vda vda Vol
-    vol vs vta zB Zech Zeph zit zzgl
+    Abb adm Adm Abs afmo alt Alt Anl ap apdo approx Approx art Art atte atto Aufl ave Ave Az
+    bmo Bmo brig Bd Brig bsp Bsp bspw bzgl bzw ca cap capt Capt cf cmdt Cmdt cnel Cnel Col Co col Col Dan Corp
+    Deut de Dr Ecc dgl Eccl dt Eph emp Est en Esth es etc Ex evtl excl exca Exca Exo excmo Exod Excmo Ezek exsmo Ezra Exsmo ff fig Fig figs Figs fr Gal Fr
+    Gen gal gen Gen ggf gral Gral GmbH gob Hab Hag Gob Heb Hd hno Hno hnos Hos Hnos Jas Isa Jer Jon Inc Josh Judg Lam incl Lev inkl lic Lic lit ldo Ldo Ltd
+    mag Mal Matt Mag max med Mic Med min Mio mos Mr mr Mrd Mrs mrs Ms ms Mt mt Nah MwSt nat Neh Nat Nr nr ntra Ntra ntro Oba Num Obad Ntro
+    Phlm pag Pro Phil phil Prov prof Ps Psalm Prof rer Rev Rer Rom resp sci Sci Sr sr Sra sra Srta srta St st synth tab Tab tel Tel
+    univ Univ Urt vda Vda vol Vol vs Zech vta Zeph zB zit zzgl
     Mon lun Tue mar Wed mie mié Thu jue Fri vie Sat sab Sun dom
     """.split()
         + list(months)
     )
+
     """Abbreviations with no dots inside."""
 
     starters = frozenset(

--- a/syntok/_segmentation_states.py
+++ b/syntok/_segmentation_states.py
@@ -67,13 +67,17 @@ class State(metaclass=ABCMeta):
 
     abbreviations = frozenset(
         """
-    Abb adm Adm Abs afmo alt Alt Anl ap apdo approx Approx art Art atte atto Aufl ave Ave Az
-    bmo Bmo brig Bd Brig bsp Bsp bspw bzgl bzw ca cap capt Capt cf cmdt Cmdt cnel Cnel Co col Col Corp
-    de Dr dgl dt emp en es etc evtl excl exca Exca excmo Excmo exsmo Exsmo ff fig Fig figs Figs fr Fr
-    gal gen Gen ggf gral Gral GmbH gob Gob Hd hno Hno hnos Hnos Inc incl inkl lic Lic lit ldo Ldo Ltd
-    mag Mag max med Med min Mio mos Mr mr Mrd Mrs mrs Ms ms Mt mt MwSt nat Nat Nr nr ntra Ntra ntro Ntro
-    pag phil prof Prof rer Rer resp sci Sci Sr sr Sra sra Srta srta St st synth tab Tab tel Tel
-    univ Univ Urt vda Vda vol Vol vs vta zB zit zzgl
+    Abb Abs Adm adm afmo Alt alt Anl ap apdo approx Approx Art art atte atto Aufl
+    ave Ave Az Bd Bmo bmo brig Brig bsp Bsp bspw bzgl bzw ca cap capt Capt cf Cmdt
+    cmdt cnel Cnel Co col Col Corp Dan de Deut dgl Dr dt Ecc Eccl emp en Eph es
+    Est Esth etc evtl Ex exca Exca excl excmo Excmo Exo Exod exsmo Exsmo Ezek Ezra
+    ff Fig fig figs Figs Fr fr Gal gal gen Gen ggf GmbH Gob gob Gral gral Hab Hag
+    Hd Heb hno Hno hnos Hnos Hos Inc incl inkl Isa Jas Jer Jon Josh Judg Lam Ldo 
+    ldo Lev Lic lic lit Ltd mag Mag Mal Matt max med Med Mic min Mio mos mr Mr Mrd
+    mrs Mrs Ms ms mt Mt MwSt Nah Nat nat Neh nr Nr Ntra ntra Ntro ntro Num Oba Obad
+    pag Phil phil Phlm Pro Prof prof Prov Ps Psalm Rer rer resp Rev Rom Sci sci Song
+    Sr sr sra Sra srta Srta St st synth tab Tab Tel tel Univ univ Urt Vda vda Vol
+    vol vs vta zB Zech Zeph zit zzgl
     Mon lun Tue mar Wed mie mié Thu jue Fri vie Sat sab Sun dom
     """.split()
         + list(months)

--- a/syntok/_segmentation_states.py
+++ b/syntok/_segmentation_states.py
@@ -68,17 +68,16 @@ class State(metaclass=ABCMeta):
     abbreviations = frozenset(
         """
     Abb adm Adm Abs afmo alt Alt Anl ap apdo approx Approx art Art atte atto Aufl ave Ave Az
-    bmo Bmo brig Bd Brig bsp Bsp bspw bzgl bzw ca cap capt Capt cf cmdt Cmdt cnel Cnel Col Co col Col Dan Corp
-    Deut de Dr Ecc dgl Eccl dt Eph emp Est en Esth es etc Ex evtl excl exca Exca Exo excmo Exod Excmo Ezek exsmo Ezra Exsmo ff fig Fig figs Figs fr Gal Fr
-    Gen gal gen Gen ggf gral Gral GmbH gob Hab Hag Gob Heb Hd hno Hno hnos Hos Hnos Jas Isa Jer Jon Inc Josh Judg Lam incl Lev inkl lic Lic lit ldo Ldo Ltd
+    bmo Bmo brig Bd Brig bsp Bsp bspw bzgl bzw ca cap capt Capt cf cmdt Cmdt cnel Cnel Co col Col Dan Corp
+    Deut de Dr dgl Ecc Eccl dt Eph emp en Est Esth es etc Ex evtl excl exca Exca Exo excmo Excmo exsmo Exsmo Exod Ezek Ezra ff fig Fig figs Figs fr Fr  
+    Gal gal Gen gen ggf gral Gral GmbH gob Hab Hag Gob Heb Hd hno Hno hnos Hos Hnos Jas Isa Jer Jon Inc Josh Judg Lam incl Lev inkl lic Lic lit ldo Ldo Ltd
     mag Mal Matt Mag max med Mic Med min Mio mos Mr mr Mrd Mrs mrs Ms ms Mt mt Nah MwSt nat Neh Nat Nr nr ntra Ntra ntro Oba Num Obad Ntro
-    Phlm pag Pro Phil phil Prov prof Ps Psalm Prof rer Rev Rer Rom resp sci Sci Sr sr Sra sra Srta srta St st synth tab Tab tel Tel
+    Phlm pag Pro Phil phil Ps prof Prof Psalm Prov rer Rev Rer Rom resp sci Sci Sr sr Sra sra Srta srta St st synth tab Tab tel Tel
     univ Univ Urt vda Vda vol Vol vs Zech vta Zeph zB zit zzgl
     Mon lun Tue mar Wed mie mié Thu jue Fri vie Sat sab Sun dom
     """.split()
         + list(months)
     )
-
     """Abbreviations with no dots inside."""
 
     starters = frozenset(

--- a/syntok/segmenter_test.py
+++ b/syntok/segmenter_test.py
@@ -378,6 +378,14 @@ class TestSegmenter(TestCase):
         result = segmenter.split(iter(tokens))
         self.assertEqual([tokens], result)
 
+    def test_do_not_split_bible_citation(self):
+        tokens = Tokenizer().split(
+            "This is not a real quote? (Phil. 4:8) No, it's not."
+        )
+        result = segmenter.split(iter(tokens))
+        self.assertEqual(len(result[0]), 7)
+        self.assertEqual(len(result[1]), 11)
+
     def test_do_not_split_short_text_inside_parenthesis2(self):
         tokens = Tokenizer().split(
             "This is (Proc. ABC with Abs. Reg. Compliance) not here."


### PR DESCRIPTION
We've seen a lot of bible citations in our data, and wanted to add a comprehensive list of bible book names as abbreviations. This makes syntok do a better job splitting bible citations of the form

> This is not a real quote? (Phil. 4:8) No, it's not.