### PR TITLE
fix not-contraction offsets + add test (resolves #15)

### DIFF
--- a/syntok/tokenizer.py
+++ b/syntok/tokenizer.py
@@ -221,8 +221,7 @@ class Tokenizer:
                     yield Token(prefix, word[remainder:mo.start() - 1], offset + remainder)
                     prefix = ""
 
-                yield Token(prefix, "not" if self.replace_not_contraction else 'n' +
-                            mo.group(0), offset + mo.start() - (0 if self.replace_not_contraction else 1))
+                yield Token(prefix, "not" if self.replace_not_contraction else 'n' + mo.group(0), offset + mo.start() - 1)
                 return ""
 
             yield Token(prefix, word[remainder:mo.start()], offset + remainder)

--- a/syntok/tokenizer.py
+++ b/syntok/tokenizer.py
@@ -221,7 +221,8 @@ class Tokenizer:
                     yield Token(prefix, word[remainder:mo.start() - 1], offset + remainder)
                     prefix = ""
 
-                yield Token(prefix, "not" if self.replace_not_contraction else 'n' + mo.group(0), offset + mo.start())
+                yield Token(prefix, "not" if self.replace_not_contraction else 'n' +
+                            mo.group(0), offset + mo.start() - (0 if self.replace_not_contraction else 1))
                 return ""
 
             yield Token(prefix, word[remainder:mo.start()], offset + remainder)

--- a/syntok/tokenizer_test.py
+++ b/syntok/tokenizer_test.py
@@ -105,7 +105,7 @@ class TestTokenizer(TestCase):
         text = "don't"
         self.tokenizer = Tokenizer(replace_not_contraction=True)
         result = self.tokenizer.split(text)
-        self.assertListEqual([t.offset for t in result], [0, 3])
+        self.assertListEqual([t.offset for t in result], [0, 2])
         self.assertListEqual([t.value for t in result], ["do", "not"])
 
 

--- a/syntok/tokenizer_test.py
+++ b/syntok/tokenizer_test.py
@@ -91,6 +91,23 @@ class TestTokenizer(TestCase):
         self.assertListEqual(s(result), ["\U0001F64C", ".", "A"])
         self.assertListEqual([t.offset for t in result], [0, 1, 2])  # requires Py3.3+
 
+    def test_apostrophe_offset_without_replace_not_contraction(self):
+        # NOTE: in this case nothing is replaced, so the offsets should remain identical
+        # to those in the original text
+        text = "don't"
+        self.tokenizer = Tokenizer(replace_not_contraction=False)
+        result = self.tokenizer.split(text)
+        self.assertListEqual([t.offset for t in result], [0, 2])
+
+    def test_apostrophe_offset_with_replace_not_contraction(self):
+        # NOTE: in this case, "n't" is replaced with "not", so a space is introduced.
+        # e.g. "don't" -> "do not", "can't" -> "can not"
+        text = "don't"
+        self.tokenizer = Tokenizer(replace_not_contraction=True)
+        result = self.tokenizer.split(text)
+        self.assertListEqual([t.offset for t in result], [0, 3])
+        self.assertListEqual([t.value for t in result], ["do", "not"])
+
 
 class TestToText(TestCase):
 


### PR DESCRIPTION
This PR implements a fix for the issue noted in #15. Specifically, in the case of "don't" you now get `do @ 0, n't @ 2` when not replacing not-contractions; if you set `replace_not_contraction=True`, you will still get `do @ 0, not @ 3` because of the implicit whitespace introduction. I assumed you would still want to introduce a space in that case, because keeping the text pristine doesn't necessarily matter there.

Let me know if you disagree or would like to see something changed!