### PR TITLE
Zero Width unicode characters

### DIFF
--- a/syntok/tokenizer.py
+++ b/syntok/tokenizer.py
@@ -71,8 +71,8 @@ class Tokenizer:
     _hyphens = "\u00AD\u058A\u05BE\u0F0C\u1400\u1806\u2010\u2011\u2012\u2e17\u30A0-"
     """Hyphen Unicode chars to be aware of when splitting."""
 
-    _hyphens_and_underscore = frozenset(_hyphens + "_" + "\u200b")
-    """The set of all hyphen Unicode chars, the underscore and the zero-width space."""
+    _hyphens_and_underscore = frozenset(_hyphens + "_" + "\u200b\u200c")
+    """The set of all hyphen Unicode chars, the underscore and the zero-width space and non-joiner."""
 
     _hyphen_newline = regex.compile(r"(?<=\p{L})[" + _hyphens + "][ \t\u00a0\r]*\n[ \t\u00a0]*(?=\\p{L})")
     """A token split across a newline with a hyphen marker."""
@@ -89,7 +89,7 @@ class Tokenizer:
         r"[" + _apostrophes + r"]\p{L}+|" +  # apostrophes and their tail
         r"[\p{Ps}\p{Pe}]|" +   # parenthesis and open/close punctuation
         r"\.\.\.|" +  # inner ellipsis
-        r"\u200b|" +  # zero width space
+        r"[\u200b\u200c]|" +  # zero width space and zero width non-joiner
         r"(?<=\p{L})[,;_" + _hyphens + r"](?=[\p{L}\p{Nd}])|" +  # dash-not-digits transition prefix
         r"(?<=[\p{L}\p{Nd}])[,;_" + _hyphens + r"](?=\p{L})"  # dash-not-digits transition postfix
     )

--- a/syntok/tokenizer.py
+++ b/syntok/tokenizer.py
@@ -71,8 +71,8 @@ class Tokenizer:
     _hyphens = "\u00AD\u058A\u05BE\u0F0C\u1400\u1806\u2010\u2011\u2012\u2e17\u30A0-"
     """Hyphen Unicode chars to be aware of when splitting."""
 
-    _hyphens_and_underscore = frozenset(_hyphens + "_")
-    """The set of all hyphen Unicode chars and the underscore."""
+    _hyphens_and_underscore = frozenset(_hyphens + "_" + "\u200b")
+    """The set of all hyphen Unicode chars, the underscore and the zero-width space."""
 
     _hyphen_newline = regex.compile(r"(?<=\p{L})[" + _hyphens + "][ \t\u00a0\r]*\n[ \t\u00a0]*(?=\\p{L})")
     """A token split across a newline with a hyphen marker."""
@@ -89,6 +89,7 @@ class Tokenizer:
         r"[" + _apostrophes + r"]\p{L}+|" +  # apostrophes and their tail
         r"[\p{Ps}\p{Pe}]|" +   # parenthesis and open/close punctuation
         r"\.\.\.|" +  # inner ellipsis
+        r"\u200b|" +  # zero width space
         r"(?<=\p{L})[,;_" + _hyphens + r"](?=[\p{L}\p{Nd}])|" +  # dash-not-digits transition prefix
         r"(?<=[\p{L}\p{Nd}])[,;_" + _hyphens + r"](?=\p{L})"  # dash-not-digits transition postfix
     )

--- a/syntok/tokenizer.py
+++ b/syntok/tokenizer.py
@@ -71,8 +71,8 @@ class Tokenizer:
     _hyphens = "\u00AD\u058A\u05BE\u0F0C\u1400\u1806\u2010\u2011\u2012\u2e17\u30A0-"
     """Hyphen Unicode chars to be aware of when splitting."""
 
-    _hyphens_and_underscore = frozenset(_hyphens + "_" + "\u200b\u200c")
-    """The set of all hyphen Unicode chars, the underscore and the zero-width space and non-joiner."""
+    _hyphens_and_underscore = frozenset(_hyphens + "_")
+    """The set of all hyphen Unicode chars and the underscore."""
 
     _hyphen_newline = regex.compile(r"(?<=\p{L})[" + _hyphens + "][ \t\u00a0\r]*\n[ \t\u00a0]*(?=\\p{L})")
     """A token split across a newline with a hyphen marker."""
@@ -89,14 +89,14 @@ class Tokenizer:
         r"[" + _apostrophes + r"]\p{L}+|" +  # apostrophes and their tail
         r"[\p{Ps}\p{Pe}]|" +   # parenthesis and open/close punctuation
         r"\.\.\.|" +  # inner ellipsis
-        r"[\u200b\u200c]|" +  # zero width space and zero width non-joiner
         r"(?<=\p{L})[,;_" + _hyphens + r"](?=[\p{L}\p{Nd}])|" +  # dash-not-digits transition prefix
         r"(?<=[\p{L}\p{Nd}])[,;_" + _hyphens + r"](?=\p{L})"  # dash-not-digits transition postfix
     )
     """Secondary regex to sub-split non-whitespace sequences."""
 
-    _spaces = regex.compile(r"\S+", regex.UNICODE)
-    """Primary regex to split strings at any kind of Unicode whitespace."""
+    # Annoyingly, unicode regex character class \S does not include the zwsp...
+    _spaces = regex.compile(r"[^\s\u200b]+", regex.UNICODE)
+    """Primary regex to split strings at any kind of Unicode whitespace and the zero width space (zwsp)."""
 
     @staticmethod
     def join_hyphenated_words_across_linebreaks(text: str) -> str:

--- a/syntok/tokenizer_test.py
+++ b/syntok/tokenizer_test.py
@@ -69,9 +69,9 @@ class TestTokenizer(TestCase):
         self.assertListEqual(s(self.tokenizer.split("ab_cd")), ["ab", "_", "cd"])
 
     def test_emit_zero_width_space(self):
-        self.assertListEqual(s(self.tokenizer.split("zero\u200Bwidth")), ["zero", "width"])
+        self.assertListEqual(s(self.tokenizer.split("zero\u200Bwidth\u200Cnon-joiner")), ["zero", "width", "non", "joiner"])
         self.tokenizer = Tokenizer(True)
-        self.assertListEqual(s(self.tokenizer.split("zero\u200Bwidth")), ["zero", "\u200B", "width"])
+        self.assertListEqual(s(self.tokenizer.split("zero\u200Bwidth\u200Cnon-joiner")), ["zero", "\u200B", "width", "\u200C", "non", "-", "joiner"])
 
     def test_spacing_prefix(self):
         text = " Hi man,  spaces !! "

--- a/syntok/tokenizer_test.py
+++ b/syntok/tokenizer_test.py
@@ -68,13 +68,8 @@ class TestTokenizer(TestCase):
         self.tokenizer = Tokenizer(True)
         self.assertListEqual(s(self.tokenizer.split("ab_cd")), ["ab", "_", "cd"])
 
-    def test_emit_zero_width_space(self):
-        self.assertListEqual(s(self.tokenizer.split("zero\u200Bwidth\u200Cnon-joiner")), ["zero", "width", "non", "joiner"])
-        self.tokenizer = Tokenizer(True)
-        self.assertListEqual(s(self.tokenizer.split("zero\u200Bwidth\u200Cnon-joiner")), ["zero", "\u200B", "width", "\u200C", "non", "-", "joiner"])
-
     def test_spacing_prefix(self):
-        text = " Hi man,  spaces !! "
+        text = " Hi man,  spaces of \u200Ball  kinds!! "
         output = self.tokenizer.split(text)
         reconstruction = "".join(map(str, output))
         self.assertEqual(text, reconstruction)

--- a/syntok/tokenizer_test.py
+++ b/syntok/tokenizer_test.py
@@ -68,6 +68,11 @@ class TestTokenizer(TestCase):
         self.tokenizer = Tokenizer(True)
         self.assertListEqual(s(self.tokenizer.split("ab_cd")), ["ab", "_", "cd"])
 
+    def test_emit_zero_width_space(self):
+        self.assertListEqual(s(self.tokenizer.split("zero\u200Bwidth")), ["zero", "width"])
+        self.tokenizer = Tokenizer(True)
+        self.assertListEqual(s(self.tokenizer.split("zero\u200Bwidth")), ["zero", "\u200B", "width"])
+
     def test_spacing_prefix(self):
         text = " Hi man,  spaces !! "
         output = self.tokenizer.split(text)

--- a/syntok/tokenizer_test.txt
+++ b/syntok/tokenizer_test.txt
@@ -38,6 +38,8 @@ Weird -usage- of hyphens.
 Weird - usage - of hyphens .
 Split hidden,sentence terminal.Here the user missed,a space.
 Split hidden , sentence terminal . Here the user missed , a space .
+Split zero width​space characters.
+Split zero width space characters .
 Special a,b a:a b;b a.b A.B and Aa.B and A!B Aa!B and A?A Aa?B
 Special a , b a:a b ; b a.b A.B and Aa . B and A!B Aa ! B and A?A Aa ? B
 Srᵃ “A&D” yes-no CaMel U.S.A. *@#$^%! $10.00 Nº (one_two): a@b.c is 1ᵃ.


### PR DESCRIPTION
Great library!

Using it on an NLP task we study, I ran into a problem processing text drawn from the Web (where you find a lot of weird stuff!).
Specifically, we want to split on \u200B and \u200C that are known as zero width space (zwsp) and zero width non-joiner, respectively.

This pull request modifies the code to do that by adding these characters to the `hyphens_and_underscore` (you may want to modify the variable name to also refer to zwsp if you decide to integrate the changes, I thought first let's see if you like the proposal). I added examples of desired behavior to the tests.

Background info:

- https://www.fileformat.info/info/unicode/char/200b/index.htm
- https://stackoverflow.com/questions/47649396/handling-u200b-zero-width-space-character-in-text-preprocessing-for-nlp-task