### PR TITLE
Fix "no. 1", "No. 1", "NO. 1" type abbreviation filtering.

### DIFF
--- a/syntok/_segmentation_states.py
+++ b/syntok/_segmentation_states.py
@@ -188,14 +188,13 @@ class State(metaclass=ABCMeta):
         return not self.is_empty and self.__queue[0].value.isnumeric()
 
     @property
-    def next_is_alphanumeric(self) -> bool:
+    def next_is_alphanumeric_containing_numeric_char(self) -> bool:
         if self.is_empty:
             return False
 
         v = self.__queue[0].value
         return (
             any(c.isnumeric() for c in v)
-            and any(c.isalpha() for c in v)
             and v.isalnum()
         )
 
@@ -389,7 +388,7 @@ class State(metaclass=ABCMeta):
         ):
             return self
 
-        elif token_before == "no" and self.next_is_alphanumeric:
+        elif token_before in ("no", "No", "NO") and self.next_is_alphanumeric_containing_numeric_char:
             return self
 
         elif self.next_is_numeric and self.next_has_no_spacing:

--- a/syntok/segmenter_test.py
+++ b/syntok/segmenter_test.py
@@ -144,6 +144,7 @@ In line with the literature on DLB.
 This is verse 14;45 in the test;
 Splitting on semi-colons.
 The discovery of low-mass nulceli (AGN; NGC 4395 and POX 52; Filippenko & Sargent 1989; Kunth et al. 1987) triggered a quest; it has yielded today more than 500 sources.
+The Company is the No. 2 and No. 3 largest chain in the U.S. and Canada, respectively, by number of stores.
 Always last, clear closing example."""
 
 SENTENCES = OSPL.split("\n")
@@ -378,9 +379,7 @@ class TestSegmenter(TestCase):
         self.assertEqual([tokens], result)
 
     def test_do_not_split_bible_citation(self):
-        tokens = Tokenizer().split(
-            "This is a bible quote? (Phil. 4:8) Yes, it is!"
-        )
+        tokens = Tokenizer().split("This is a bible quote? (Phil. 4:8) Yes, it is!")
         result = segmenter.split(iter(tokens))
         self.assertEqual(len(result[0]), 6)
         self.assertEqual(len(result[1]), 5)
@@ -463,12 +462,16 @@ class TestSegmenter(TestCase):
         self.assertEqual([tokens], result)
 
     def test_no_split_on_strange_text(self):
-        tokens = Tokenizer().split("Four patients (67%) with an average response of 3.3 mos. (range 6 wks. to 12 mos.)")
+        tokens = Tokenizer().split(
+            "Four patients (67%) with an average response of 3.3 mos. (range 6 wks. to 12 mos.)"
+        )
         result = segmenter.split(iter(tokens))
         self.assertEqual([tokens], result)
 
     def test_no_split_on_strange_text2(self):
-        tokens = Tokenizer().split("Packed cells (PRBC) for less than 20,000 thousand/micro.L, repsectively.")
+        tokens = Tokenizer().split(
+            "Packed cells (PRBC) for less than 20,000 thousand/micro.L, repsectively."
+        )
         result = segmenter.split(iter(tokens))
         self.assertEqual([tokens], result)
 


### PR DESCRIPTION
Fixes: #21

Previous code expected only lowercase "no" abbreviation. "No" is also fairly common, and "NO" is also added for all-capitalized texts.
Previous code expected it to follow with alphanumeric token, which contains at least 1 numeric and 1 alpha. Removed the "at least 1 alpha" constraint.
The helper method "next_is_alphanumeric" was only used at "no" type abbreviation check. Further specified helper method name, to avoid confusion.