### PR TITLE
Fix false positive month abbreviation

### DIFF
--- a/syntok/_segmentation_states.py
+++ b/syntok/_segmentation_states.py
@@ -76,7 +76,6 @@ class State(metaclass=ABCMeta):
     univ Univ Urt vda Vda vol Vol vs vta zB zit zzgl
     Mon lun Tue mar Wed mie mié Thu jue Fri vie Sat sab Sun dom
     """.split()
-        + list(months)
     )
     """Abbreviations with no dots inside."""
 

--- a/syntok/_segmentation_states.py
+++ b/syntok/_segmentation_states.py
@@ -407,6 +407,9 @@ class State(metaclass=ABCMeta):
         elif token_before.isnumeric() and self.next_is_month_abbreviation:
             return self
 
+        elif token_before in State.months and self.next_is_numeric:
+            return self
+
         elif "." in token_before and token_after != ".":
             return self
 

--- a/syntok/segmenter_test.py
+++ b/syntok/segmenter_test.py
@@ -276,6 +276,22 @@ class TestSegmenter(TestCase):
         result = segmenter.split(iter(tokens))
         self.assertEqual([tokens[:sep], tokens[sep:]], result)
 
+    def test_sentences_ending_with_false_positive_month_abbreviation_1(self):
+        tokens = Tokenizer().split(
+            "Some of the cookies are essential for parts of the site to operate and have already been set. You may delete and block all cookies from this site, but if you do, parts of the site may not work."
+        )
+        sep = 19
+        result = segmenter.split(iter(tokens))
+        self.assertEqual([tokens[:sep], tokens[sep:]], result)
+
+    def test_sentences_ending_with_false_positive_month_abbreviation_2(self):
+        tokens = Tokenizer().split(
+            "The sharpshooter appears to be checked out on his Kings experience, and an argument could easily be raised that he should have been moved two years ago. Now, his $23 million salary will be a tough pill for teams to swallow, even if there is decent chance of a solid bounce-back year at a new destination."
+        )
+        sep = 29
+        result = segmenter.split(iter(tokens))
+        self.assertEqual([tokens[:sep], tokens[sep:]], result)
+
     def test_sentences_with_enumerations(self):
         tokens = Tokenizer().split("1. This goes first. 2. And here thereafter.")
         sep = 6

--- a/syntok/segmenter_test.py
+++ b/syntok/segmenter_test.py
@@ -87,6 +87,7 @@ This is a sentence terminal ellipsis...
 This is another sentence terminal ellipsis....
 An easy to handle G. species mention.
 Am 13. Jän. 2006 war es regnerisch.
+And on Jan. 22, 2022 it was, too.
 (Phil. 4:8)
 (Oh. Again!)
 Syntok even handles bible quotes!


### PR DESCRIPTION
Fixes #22
Some month abbreviations are also valid English words (e.g.: "set", "ago"), which cases false positives if we are treating month abberviations as generic abbrevations, as it would consume such sentence endings.
Code already contains logic to check if month abbreviation is preceeded by number, see test-case: "Am 13. Jän. 2006 war es regnerisch."